### PR TITLE
add geometry support to _meta

### DIFF
--- a/bufr2geojson/__init__.py
+++ b/bufr2geojson/__init__.py
@@ -752,6 +752,7 @@ class BUFRParser:
                         "_meta": {
                             "data_date": self.get_time(),
                             "identifier": feature_id,
+                            "geometry": self.get_location(),
                             "metadata_hash": metadata_hash
                         },
                         "_headers": deepcopy(headers)

--- a/bufr2geojson/__init__.py
+++ b/bufr2geojson/__init__.py
@@ -164,7 +164,7 @@ class BUFRParser:
         # get class of descriptor
         xx = fxxyyy[1:3]
         # first check whether the value is None, if so remove and exit
-        if (value is None) and (description is None):
+        if [value, description] == [None, None]:
             if key in self.qualifiers[xx]:
                 del self.qualifiers[xx][key]
         else:
@@ -230,6 +230,10 @@ class BUFRParser:
                 value = self.qualifiers[c][k]["value"]
                 units = self.qualifiers[c][k]["attributes"]["units"]
                 description = self.qualifiers[c][k]["description"]
+                try:
+                    description = description.strip()
+                except AttributeError:
+                    pass
                 q = {
                     "name": name,
                     "value": value,
@@ -520,7 +524,7 @@ class BUFRParser:
             LOGGER.debug(self.qualifiers["01"])
 
         # now set wsi in return value
-        station_id["wsi"] = wigosID
+        station_id["wsi"] = wigosID.strip()
 
         return station_id
 

--- a/tests/test_bufr2geojson.py
+++ b/tests/test_bufr2geojson.py
@@ -78,7 +78,7 @@ def geojson_output():
                     'name': 'station_or_site_name',
                     'value': None,
                     'units': 'CCITT IA5',
-                    'description': 'SHERKIN ISLAND      '
+                    'description': 'SHERKIN ISLAND'
                 },
                 {
                     'name': 'station_type',


### PR DESCRIPTION
Similar to https://github.com/wmo-im/csv2bufr/pull/72, this PR adds GeoJSON geometry to the a result's _meta object so that they can be used in downstream processing (without processing the data payload) as desired. The context here is wis2box MQP message publishing (which is GeoJSON).
